### PR TITLE
Made the installation instructions clear.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## What is this?
 
-In order for you to view your selfhosted logs, you have to deploy this application. Take the url of this app after you deploy it and input it as a config var `LOG_URL` in the modmail bot app.
+In order for you to view your selfhosted logs, you have to deploy this application. Before you deploy the application, create a config var named `MONGO_URI` and put your MongoDB connection URI from the previous section into the value slot. Take the url of this app after you deploy it and input it as a config var `LOG_URL` in the modmail bot app.
 
 ## Contributing
 


### PR DESCRIPTION
Added clear directions on how to properly setup the log app as it was not clear that the app required a config var even though if someone was smart enough they could have figured this out.