### PR TITLE
Fix infinite onerror loop in avatar image loader

### DIFF
--- a/templates/logbase.html
+++ b/templates/logbase.html
@@ -41,7 +41,7 @@
         <div class="info__guild-icon-container">
             <img class="info__guild-icon hoverable"
                  src="{{ log_entry.recipient.avatar_url }}"
-                 onerror="this.src='{{ log_entry.recipient.default_avatar_url }}'"
+                 onerror="this.onerror=null;this.src='{{ log_entry.recipient.default_avatar_url }}'"
                  alt="avatar">
         </div>
         <div class="info__metadata">
@@ -81,7 +81,7 @@
                 <div class="chatlog__author-avatar-container">
                         <img class="chatlog__author-avatar"
                              src="{{ group.author.avatar_url }}"
-                             onerror="this.src='{{ group.author.default_avatar_url }}'"
+                             onerror="this.onerror=null;this.src='{{ group.author.default_avatar_url }}'"
                              alt="avatar"/>
                 </div>
 


### PR DESCRIPTION
Avatar images have an onerror attribute to set their image to a generic avatar image if they fail to load from discord. However, in situations where the network fails or the discord CDN is unavailable for some reason (adblockers), this will throw an error as well.

In browsers other than chrome, this will trigger the on-error handler again, infinitely looping requests as fast as possible. 

We set the onerror handler to null before making the new request to get around this and ensure if the fallback fails to load we don't make further requests.